### PR TITLE
[INC-66906] Supporting Schemas and Tables in All Languages.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -133,7 +133,7 @@ class SessionCatalog(
   @GuardedBy("this")
   protected var currentDb: String = format(defaultDatabase)
 
-  private val validNameFormat = "([\\w_]+)".r
+  private var validNameFormat = "([\\w_]+)".r
 
   /**
    * Checks if the given name conforms the Hive standard ("[a-zA-Z_0-9]+"),
@@ -143,6 +143,9 @@ class SessionCatalog(
    * org.apache.hadoop.hive.metastore.MetaStoreUtils.validateName.
    */
   private def validateName(name: String): Unit = {
+    if (conf.allLanguagesSupported) {
+      validNameFormat = "(\\p{IsAlphabetic}|\\p{Sc}|_|\\p{IsDigit})+".r;
+    }
     if (!validNameFormat.pattern.matcher(name).matches()) {
       throw QueryCompilationErrors.invalidNameForTableOrDatabaseError(name)
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4027,6 +4027,14 @@ object SQLConf {
     .checkValues(ErrorMessageFormat.values.map(_.toString))
     .createWithDefault(ErrorMessageFormat.PRETTY.toString)
 
+  val SUPPORT_ALL_LANGUAGES = buildConf("spark.sql.support.all.languages")
+      .doc("Set this flag to enable creating schemas and tables in all languages." +
+        " Clearing the flag permits creating schemas and tables in English only.")
+      .version("3.4.1")
+      .booleanConf
+      .createWithDefault(true)
+
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -4837,6 +4845,8 @@ class SQLConf extends Serializable with Logging {
 
   def allowsTempViewCreationWithMultipleNameparts: Boolean =
     getConf(SQLConf.ALLOW_TEMP_VIEW_CREATION_WITH_MULTIPLE_NAME_PARTS)
+
+  def allLanguagesSupported: Boolean = getConf(SQLConf.SUPPORT_ALL_LANGUAGES)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -114,7 +114,7 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
   def testInvalidName(func: (String) => Unit): Unit = {
     // scalastyle:off
     // non ascii characters are not allowed in the source code, so we disable the scalastyle.
-    val name = "砖"
+    val name = "砖#$"
     // scalastyle:on
     val e = intercept[AnalysisException] {
       func(name)


### PR DESCRIPTION
Spark support schemas and tables in English language only; in order to comply with hive.
This commit fixes that to support all languages.
Added a new configuration "spark.sql.support.all.languages", if enabled, it supports schemas and tables
in all languages. Enabled by default. When cleared, it'll fall back to Spark's original
behavior.